### PR TITLE
translate element title in edit form

### DIFF
--- a/src/includes/form.theme.inc.js
+++ b/src/includes/form.theme.inc.js
@@ -99,7 +99,7 @@ function theme_form_element_label(variables) {
     if (element.type == 'radios') { label_for = element.name; }
     // Render the label.
     var html =
-      '<label for="' + label_for + '"><strong>' + element.title + '</strong>';
+      '<label for="' + label_for + '"><strong>' + t(element.title) + '</strong>';
     if (element.required) { html += theme('form_required_marker', { }); }
     html += '</label>';
     return html;


### PR DESCRIPTION
I found the element title was not translated in multi-language, add this t function, it's ok now.
