### PR TITLE
modify comment body language setting

### DIFF
--- a/src/modules/entity/entity.js
+++ b/src/modules/entity/entity.js
@@ -557,6 +557,8 @@ function drupalgap_entity_build_from_form_state(form, form_state) {
       }
       else if (typeof value !== 'undefined') { entity[name] = value; }
     }
+    entity['comment_body']['und'] = entity['comment_body'][language];
+    delete entity['comment_body'][language];
     return entity;
   }
   catch (error) {


### PR DESCRIPTION
When I use multi-language other then English to leave a comment, always met prompt '(Comment) - Comment field is required.'
I checked many places, finally I found the problem: system only have entity['comment_body'][language], but the form submit need entity['comment_body']['und'], so I made above change (maybe there is some better way to change), and
